### PR TITLE
CI(github-packages):  bump actions version

### DIFF
--- a/.github/workflows/github-packages.yml
+++ b/.github/workflows/github-packages.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm ci
@@ -21,8 +21,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com/


### PR DESCRIPTION
This PR updates versions of the github actions to v4.

## Changes

Bumped Github Actions(like setup-node, checkout) to v4(latest)

## Why 

This change updates the nodejs versions internally in github actions, [As said by github they have deprecated nodejs v16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) and transition to **v20**

Also removes the warning displayed in CI logs/output to upgrade.

## ✅ Checkmarks

- [x] closely Verified to make sure this are the correct changes

## Additional information
References Used for verification: 
1. https://github.com/actions/checkout/releases/tag/v4.0.0
2. https://github.com/actions/setup-node/releases/tag/v4.0.0
3. (Already linked in "why" section) https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
